### PR TITLE
Updated problem_16.md

### DIFF
--- a/Notes/problem_16.md
+++ b/Notes/problem_16.md
@@ -13,8 +13,8 @@ template<typename T> class vector {
     ...
     public:
         iterator insert(iterator posn, const T&x) {
-            increaseCap();
             ptrdiff_t offset = posn - begin(); // ptrdiff_t incase result is negative (in general)
+            increaseCap();
             iterator newPosn = begin() + offset;
             new(static_cast<void*>(end()) T(std::move(*(end() - 1)));
             ++vb.n;


### PR DESCRIPTION
increaseCap() might create a new vector base if it needs to grow, and so we should calculate the offset first. That way, we have avoid having possibly undefined behavior from "subtracting" two pointers who point to different memory blocks. In the event that increaseCap() would resize, posn would still point to the old array (and be invalidated) whereas begin() would point the the new array, being two separate memory blocks.