### PR TITLE
Fix namespace for problem 3

### DIFF
--- a/Notes/problem_3.md
+++ b/Notes/problem_3.md
@@ -35,21 +35,21 @@ namespace CS246E {
         size_t size, cap;
         int *theVector;
     }
+
+    const size_t startsize = 1;
+
+    vector make_vector();
+
+    size_t size(const vector &v);
+
+    int &itemAt(const vector &v, size_t i);
+
+    void push_back(const vector &v, int x);
+
+    void pop_back(const vector&v);
+
+    void dispose(vector &v);
 };
-
-const size_t startsize = 1;
-
-vector make_vector();
-
-size_t size(const vector &v);
-
-int &itemAt(const vector &v, size_t i);
-
-void push_back(const vector &v, int x);
-
-void pop_back(const vector&v);
-
-void dispose(vector &v);
 
 #endif
 ```


### PR DESCRIPTION
These methods should be inside the namespace, because inside the `vector.cc` snippet after it, we are using `CS246E::make_vector` instead of just `make_vector`.

https://notes.sibeliusp.com/pdf/1189/cs246e.pdf can be a reference of the same code snippet.